### PR TITLE
Changed crontab emails

### DIFF
--- a/crontab
+++ b/crontab
@@ -1,4 +1,4 @@
-MAILTO=benoit@claise.be,evyncke@cisco.com,miroslav.kovac@pantheon.tech,slavomir.mazur@pantheon.tech
+MAILTO=foo@bar.com
 SHELL=/bin/bash
 #
 # For more information see the manual pages of crontab(5) and cron(8)


### PR DESCRIPTION
- Emails removed from crontab, to avoid sending an emails during development

Signed-off-by: Slavomir Mazur <slavomir.mazur@pantheon.tech>