### PR TITLE
Remove unused script options

### DIFF
--- a/bin/checkArchivedDrafts.py
+++ b/bin/checkArchivedDrafts.py
@@ -48,17 +48,10 @@ def main():
     protocol = config.get('Web-Section', 'protocol-api')
     var_path = config.get('Directory-Section', 'var')
 
+    archived_draft_path = os.path.join(ietf_directory, 'my-id-archive-mirror')
+    yang_path = os.path.join(ietf_directory, 'archived-drafts-modules')
+
     parser = argparse.ArgumentParser(description='Check if modules from all the Drafts are populated in YANG Catalog')
-    parser.add_argument('--draftpath',
-                        help='Path to the directory where all the drafts will be stored. '
-                             'Default is {}/my-id-archive-mirror/'.format(ietf_directory),
-                        type=str,
-                        default='{}/my-id-archive-mirror/'.format(ietf_directory))
-    parser.add_argument('--yangpath',
-                        help='Path to the directory where all the modules should be extracted. '
-                             'Default is {}/archived-drafts-modules'.format(temp_dir),
-                        type=str,
-                        default='{}/archived-drafts-modules/'.format(temp_dir))
     parser.add_argument('--debug',
                         help='Debug level - default is 0',
                         type=int,
@@ -70,18 +63,18 @@ def main():
     all_yang_drafts_strict = os.path.join(temp_dir, 'draft-with-YANG-strict')
     missing_modules_directory = os.path.join(temp_dir, 'drafts-missing-modules')
     draft_extractor_paths = {
-        'draft_path': args.draftpath,
-        'yang_path': args.yangpath,
+        'draft_path': archived_draft_path,
+        'yang_path': yang_path,
         'all_yang_draft_path_strict': all_yang_drafts_strict,
         'all_yang_path': '{}/YANG-ALL'.format(temp_dir)
     }
 
     try:
-        remove_directory_content(args.yangpath, args.debug)
+        remove_directory_content(yang_path, args.debug)
         remove_directory_content(missing_modules_directory, args.debug)
         remove_directory_content(all_yang_drafts_strict, args.debug)
 
-        custom_print('Extracting modules from drafts stored in {}'.format(args.draftpath))
+        custom_print('Extracting modules from drafts stored in {}'.format(archived_draft_path))
         draftExtractor = DraftExtractor(draft_extractor_paths, args.debug, extract_elements=False, extract_examples=False)
         draftExtractor.extract_drafts()
         draftExtractor.invert_dict()
@@ -132,7 +125,7 @@ def main():
             name_revision += '@1970-01-01'
         if name_revision not in all_modules_keys:
             missing_modules.append(yang_file)
-            src = os.path.join(args.yangpath, yang_file)
+            src = os.path.join(yang_path, yang_file)
             dst = os.path.join(dst_path, yang_file)
             shutil.copy2(src, dst)
 
@@ -140,7 +133,7 @@ def main():
     for module in missing_modules:
         print(module)
 
-    shutil.rmtree(args.yangpath)
+    shutil.rmtree(yang_path)
     shutil.rmtree(all_yang_drafts_strict)
 
     if missing_modules:

--- a/bin/cronjob-daily
+++ b/bin/cronjob-daily
@@ -25,7 +25,7 @@ date +"%c: Starting runIETFstats.sh"
 runIETFstats.sh
 date +"%c: Starting rename-file-backup.py"
 mkdir -p $BACKUPDIR
-python rename-file-backup.py --documentpath=$WEB_PRIVATE/ --backuppath=$BACKUPDIR/
+python rename-file-backup.py
 date +"%c: Starting runGenerateMainPage.sh"
 runGenerateMainPage.sh
 date +"%c: Starting runGenerateFiguresAndStats.sh"

--- a/bin/extract_emails.py
+++ b/bin/extract_emails.py
@@ -85,12 +85,9 @@ if __name__ == '__main__':
     config = create_config()
     ietf_directory = config.get('Directory-Section', 'ietf-directory')
 
+    draft_path = config.get('Directory-Section', 'ietf-drafts')
+
     parser = argparse.ArgumentParser(description='Extract comma-separated list of email addresses')
-    parser.add_argument('--draftpath',
-                        help='Path to the directory where all the drafts will be stored. '
-                             'Default is {}/my-id-mirror/'.format(ietf_directory),
-                        type=str,
-                        default='{}/my-id-mirror/'.format(ietf_directory))
     parser.add_argument('--debug',
                         help='Debug level - default is 0',
                         type=int,
@@ -99,9 +96,9 @@ if __name__ == '__main__':
 
     debug_level = args.debug
 
-    os.chdir(args.draftpath)
+    os.chdir(draft_path)
 
-    ietf_drafts = list_of_ietf_drafts(args.draftpath)
+    ietf_drafts = list_of_ietf_drafts(draft_path)
     for draft_file in ietf_drafts:
         output = extract_email_string(draft_file, '@cisco.com', debug_level)
         if output and debug_level > 0:

--- a/bin/extractors/dratfExtractor.py
+++ b/bin/extractors/dratfExtractor.py
@@ -71,7 +71,7 @@ class DraftExtractor:
 
     def extract_drafts(self):
         for draft_file in self.ietf_drafts:
-            draft_file_path = '{}{}'.format(self.draft_path, draft_file)
+            draft_file_path = os.path.join(self.draft_path, draft_file)
 
             # Extract the correctly formatted YANG Models into yang_path
             extracted_yang_models = self.extract_from_draft_file(draft_file, self.draft_path, self.yang_path, strict=True)
@@ -163,7 +163,7 @@ class DraftExtractor:
         for extracted_model in extracted_yang_models:
             if not extracted_model.startswith('example-'):
                 print('Identifier definition extraction for {}'.format(extracted_model))
-                module_fname = '{}{}'.format(self.yang_path, extracted_model)
+                module_fname = os.path.join(self.yang_path, extracted_model)
                 extract_elem(module_fname, self.draft_elements_path, 'typedef')
                 extract_elem(module_fname, self.draft_elements_path, 'grouping')
                 extract_elem(module_fname, self.draft_elements_path, 'identity')

--- a/bin/extractors/rfcExtractor.py
+++ b/bin/extractors/rfcExtractor.py
@@ -61,7 +61,7 @@ class RFCExtractor:
                 for extracted_model in extracted_yang_models:
                     if not extracted_model.startswith('example-'):
                         print('Identifier definition extraction for {}'.format(extracted_model))
-                        module_fname = '{}{}'.format(self.rfc_yang_path, extracted_model)
+                        module_fname = os.path.join(self.rfc_yang_path, extracted_model)
                         extract_elem(module_fname, self.rfc_extraction_yang_path, 'typedef')
                         extract_elem(module_fname, self.rfc_extraction_yang_path, 'grouping')
                         extract_elem(module_fname, self.rfc_extraction_yang_path, 'identity')
@@ -92,8 +92,8 @@ class RFCExtractor:
             old_modules = json.load(f)
 
         for old_module in old_modules:
-            src_path = '{}{}'.format(srcdir, old_module)
-            dst_path = '{}{}'.format(dstdir, old_module)
+            src_path = os.path.join(srcdir, old_module)
+            dst_path = os.path.join(dstdir, old_module)
             if not os.path.isfile(src_path):
                 continue
             try:

--- a/bin/generatePrivatePage.py
+++ b/bin/generatePrivatePage.py
@@ -43,11 +43,6 @@ def render(tpl_path: str, context: dict):
 
 def main():
     parser = argparse.ArgumentParser(description='Generate yangcatalog main private page.')
-    parser.add_argument('--config',
-                        help='Path to the config file '
-                             'Default is {}'.format(os.environ['YANGCATALOG_CONFIG_PATH']),
-                        type=str,
-                        default=os.environ['YANGCATALOG_CONFIG_PATH'])
     parser.add_argument('--openRoadM',
                         help='List of openRoadM files',
                         type=str,
@@ -55,7 +50,7 @@ def main():
                         default=[])
     args = parser.parse_args()
 
-    config = create_config(args.config)
+    config = create_config()
     private_dir = config.get('Web-Section', 'private-directory')
     yang_repo_dir = config.get('Directory-Section', 'yang-models-dir')
 

--- a/bin/rename-file-backup.py
+++ b/bin/rename-file-backup.py
@@ -30,16 +30,6 @@ if __name__ == '__main__':
     web_private = config.get('Web-Section', 'private-directory')
     backup_directory = config.get('Directory-Section', 'backup')
     parser = argparse.ArgumentParser(description='Append creation timestamps to filenames')
-    parser.add_argument('--documentpath',
-                        help='Directory containing the file to backup. '
-                             'Default is {}'.format(web_private),
-                        type=str,
-                        default=web_private)
-    parser.add_argument('--backuppath',
-                        help='Directory where to backup the file. '
-                             'Default is {}'.format(backup_directory),
-                        type=str,
-                        default=backup_directory)
     parser.add_argument('--debug',
                         help='Debug level - default is 0',
                         type=int,
@@ -58,14 +48,14 @@ if __name__ == '__main__':
     for file in name_to_backup:
         file_no_extension = file.split('.')[0]
         file_extension = file.split('.')[-1]
-        full_path_file = os.path.join(args.documentpath, file)
+        full_path_file = os.path.join(web_private, file)
         if os.path.isfile(full_path_file):
             modifiedTime = os.path.getmtime(full_path_file)
             timestamp = (datetime.fromtimestamp(modifiedTime).strftime("%Y_%m_%d"))
             if file_no_extension == 'IETFYANGRFC':
                 file_no_extension = 'IETFYANGOutOfRFC'
             new_filename = '{}_{}.{}'.format(file_no_extension, timestamp, file_extension)
-            new_full_path_file = os.path.join(args.backuppath, new_filename)
+            new_full_path_file = os.path.join(backup_directory, new_filename)
             if debug_level > 0:
                 print("file full path: " + full_path_file)
                 print("file without extension: " + file_no_extension)

--- a/bin/runIETFstats.sh
+++ b/bin/runIETFstats.sh
@@ -108,10 +108,9 @@ ln -f -s $NONIETFDIR/yangmodels/yang/standard/iana/ $MODULES/iana
 date +"%c: Starting to extract all YANG modules from IETF documents" >>$LOG
 # Using --draftpath $IETFDIR/my-id-archive-mirror/ means much longer process as all expired drafts will also be analyzed...
 if [ $(date +%u) -eq 6 ]; then
-	python $BIN/yangIetf.py --draftpath $IETFDIR/my-id-archive-mirror/ >>$LOG 2>&1
+	python $BIN/yangIetf.py --archived >>$LOG 2>&1
 fi
 python $BIN/yangIetf.py >>$LOG 2>&1
-# python $BIN/yangIetf.py --draftpath $IETFDIR/my-id-archive-mirror/ >>$LOG 2>&1
 date +"%c: Finished extracting all YANG modules from IETF documents" >>$LOG
 
 # Clean up of the .fxs files created by confdc

--- a/bin/runYANGgenericstats.sh
+++ b/bin/runYANGgenericstats.sh
@@ -47,47 +47,47 @@ date +"%c: forking all sub-processes" >>$LOG
 declare -a PIDS
 
 # BBF
-(python $BIN/yangGeneric.py --metadata "BBF Complete Report: YANG Data Models compilation from https://github.com/BroadbandForum/yang/tree/master" --lint True --prefix BBF --rootdir "$TMP/bbf/" >>$LOG 2>&1) &
+(python $BIN/yangGeneric.py --metadata "BBF Complete Report: YANG Data Models compilation from https://github.com/BroadbandForum/yang/tree/master" --lint --prefix BBF --rootdir "$TMP/bbf/" >>$LOG 2>&1) &
 PIDS+=("$!")
 
 # Standard MEF
-(python $BIN/yangGeneric.py --metadata "MEF: Standard YANG Data Models compilation from https://github.com/MEF-GIT/YANG-public/tree/master/src/model/standard/" --lint True --prefix MEFStandard --rootdir "$NONIETFDIR/mef/YANG-public/src/model/standard/" >>$LOG 2>&1) &
+(python $BIN/yangGeneric.py --metadata "MEF: Standard YANG Data Models compilation from https://github.com/MEF-GIT/YANG-public/tree/master/src/model/standard/" --lint --prefix MEFStandard --rootdir "$NONIETFDIR/mef/YANG-public/src/model/standard/" >>$LOG 2>&1) &
 PIDS+=("$!")
 
 # Experimental MEF
-(python $BIN/yangGeneric.py --metadata "MEF: Draft YANG Data Models compilation from https://github.com/MEF-GIT/YANG-public/tree/master/src/model/draft/" --lint True --prefix MEFExperimental --rootdir "$NONIETFDIR/mef/YANG-public/src/model/draft/" >>$LOG 2>&1) &
+(python $BIN/yangGeneric.py --metadata "MEF: Draft YANG Data Models compilation from https://github.com/MEF-GIT/YANG-public/tree/master/src/model/draft/" --lint --prefix MEFExperimental --rootdir "$NONIETFDIR/mef/YANG-public/src/model/draft/" >>$LOG 2>&1) &
 PIDS+=("$!")
 
 # Standard IEEE published
-(python $BIN/yangGeneric.py --metadata "IEEE: YANG Data Models compilation from https://github.com/YangModels/yang/tree/master/standard/ieee/published: The 'standard/ieee/published' branch is intended for published standards modules (with approved PARs)." --lint True --prefix IEEEStandard --rootdir "$NONIETFDIR/yangmodels/yang/standard/ieee/published/" >>$LOG 2>&1) &
+(python $BIN/yangGeneric.py --metadata "IEEE: YANG Data Models compilation from https://github.com/YangModels/yang/tree/master/standard/ieee/published: The 'standard/ieee/published' branch is intended for published standards modules (with approved PARs)." --lint --prefix IEEEStandard --rootdir "$NONIETFDIR/yangmodels/yang/standard/ieee/published/" >>$LOG 2>&1) &
 PIDS+=("$!")
 
 # Standard IEEE drafts
-(python $BIN/yangGeneric.py --metadata "IEEE: YANG Data Models compilation from https://github.com/YangModels/yang/tree/master/standard/ieee/draft: The 'standard/ieee/draft' branch is intended for draft modules with an approved Project Authorization Request (PAR)." --lint True --prefix IEEEStandardDraft --rootdir "$NONIETFDIR/yangmodels/yang/standard/ieee/draft/" >>$LOG 2>&1) &
+(python $BIN/yangGeneric.py --metadata "IEEE: YANG Data Models compilation from https://github.com/YangModels/yang/tree/master/standard/ieee/draft: The 'standard/ieee/draft' branch is intended for draft modules with an approved Project Authorization Request (PAR)." --lint --prefix IEEEStandardDraft --rootdir "$NONIETFDIR/yangmodels/yang/standard/ieee/draft/" >>$LOG 2>&1) &
 PIDS+=("$!")
 
 # Experimental IEEE
-(python $BIN/yangGeneric.py --metadata "IEEE: Draft YANG Data Models compilation from https://github.com/YangModels/yang/tree/master/experimental/ieee: The 'experimental/ieee' branch is intended for IEEE work that does not yet have a Project Authorization Request (PAR)." --lint True --prefix IEEEExperimental --rootdir "$NONIETFDIR/yangmodels/yang/experimental/ieee/" --forcecompilation True >>$LOG 2>&1) &
+(python $BIN/yangGeneric.py --metadata "IEEE: Draft YANG Data Models compilation from https://github.com/YangModels/yang/tree/master/experimental/ieee: The 'experimental/ieee' branch is intended for IEEE work that does not yet have a Project Authorization Request (PAR)." --lint --prefix IEEEExperimental --rootdir "$NONIETFDIR/yangmodels/yang/experimental/ieee/" --forcecompilation True >>$LOG 2>&1) &
 PIDS+=("$!")
 
 # Standard IANA
-(python $BIN/yangGeneric.py --metadata "IANA: Standard YANG Data Models compilation from https://github.com/YangModels/yang/tree/master/standard/iana: The 'standard/iana' branch is intended for IANA-maintained YANG models." --lint True --prefix IANAStandard --rootdir "$NONIETFDIR/yangmodels/yang/standard/iana/" >>$LOG 2>&1) &
+(python $BIN/yangGeneric.py --metadata "IANA: Standard YANG Data Models compilation from https://github.com/YangModels/yang/tree/master/standard/iana: The 'standard/iana' branch is intended for IANA-maintained YANG models." --lint --prefix IANAStandard --rootdir "$NONIETFDIR/yangmodels/yang/standard/iana/" >>$LOG 2>&1) &
 PIDS+=("$!")
 
 # Openconfig
-(python $BIN/yangGeneric.py --metadata "Openconfig: YANG Data Models compilation from https://github.com/openconfig/public" --lint True --prefix Openconfig --rootdir "$NONIETFDIR/openconfig/public/release/models/" >>$LOG 2>&1) &
+(python $BIN/yangGeneric.py --metadata "Openconfig: YANG Data Models compilation from https://github.com/openconfig/public" --lint --prefix Openconfig --rootdir "$NONIETFDIR/openconfig/public/release/models/" >>$LOG 2>&1) &
 PIDS+=("$!")
 
 # ONF Open Transport
-(python $BIN/yangGeneric.py --metadata "ONF Open Transport: YANG Data Models compilation from https://github.com/OpenNetworkingFoundation/Snowmass-ONFOpenTransport" --lint True --prefix ONFOpenTransport --rootdir "$NONIETFDIR/onf/Snowmass-ONFOpenTransport" >>$LOG 2>&1) &
+(python $BIN/yangGeneric.py --metadata "ONF Open Transport: YANG Data Models compilation from https://github.com/OpenNetworkingFoundation/Snowmass-ONFOpenTransport" --lint --prefix ONFOpenTransport --rootdir "$NONIETFDIR/onf/Snowmass-ONFOpenTransport" >>$LOG 2>&1) &
 PIDS+=("$!")
 
 # sysrepo internal
-(python $BIN/yangGeneric.py --metadata "Sysrepo: internal YANG Data Models compilation from https://github.com/sysrepo/yang/tree/master/internal" --lint True --prefix SysrepoInternal --rootdir "$NONIETFDIR/sysrepo/yang/internal/" >>$LOG 2>&1) &
+(python $BIN/yangGeneric.py --metadata "Sysrepo: internal YANG Data Models compilation from https://github.com/sysrepo/yang/tree/master/internal" --lint --prefix SysrepoInternal --rootdir "$NONIETFDIR/sysrepo/yang/internal/" >>$LOG 2>&1) &
 PIDS+=("$!")
 
 # sysrepo applications
-(python $BIN/yangGeneric.py --metadata "Sysrepo: applications YANG Data Models compilation from https://github.com/sysrepo/yang/tree/master/applications" --lint True --prefix SysrepoApplication --rootdir "$NONIETFDIR/sysrepo/yang/applications/" >>$LOG 2>&1) &
+(python $BIN/yangGeneric.py --metadata "Sysrepo: applications YANG Data Models compilation from https://github.com/sysrepo/yang/tree/master/applications" --lint --prefix SysrepoApplication --rootdir "$NONIETFDIR/sysrepo/yang/applications/" >>$LOG 2>&1) &
 PIDS+=("$!")
 
 # Wait for all child-processes
@@ -101,7 +101,7 @@ for path in $(ls -d $NONIETFDIR/yangmodels/yang/standard/etsi/*); do
    version=${path##*/etsi/NFV-SOL006-}
    version_number=${version##*v}
    version_alnum=$(echo $version_number | tr -cd '[:alnum:]')
-   (python $BIN/yangGeneric.py --metadata "ETSI Complete Report: YANG Data Models compilation from https://github.com/etsi-forge/nfv-sol006/tree/$version" --lint True --prefix ETSI$version_alnum --rootdir "$NONIETFDIR/yangmodels/yang/standard/etsi/NFV-SOL006-$version/src/yang" >>$LOG 2>&1) &
+   (python $BIN/yangGeneric.py --metadata "ETSI Complete Report: YANG Data Models compilation from https://github.com/etsi-forge/nfv-sol006/tree/$version" --lint --prefix ETSI$version_alnum --rootdir "$NONIETFDIR/yangmodels/yang/standard/etsi/NFV-SOL006-$version/src/yang" >>$LOG 2>&1) &
    PIDSETSI+=("$!")
 done
 # Wait for all child-processes
@@ -134,7 +134,7 @@ if [ "$IS_PROD" = "True" ]; then
    for path in $(ls -d $TMP/openroadm-public/*/); do
       ((running = running + 1))
       version=$(basename $path)
-      (python $BIN/yangGeneric.py --metadata "OpenRoadm $version: YANG Data Models compilation from https://github.com/OpenROADM/OpenROADM_MSA_Public/tree/master/model" --lint True --prefix OpenROADM$version --rootdir "$TMP/openroadm-public/$version/" >>$LOG 2>&1) &
+      (python $BIN/yangGeneric.py --metadata "OpenRoadm $version: YANG Data Models compilation from https://github.com/OpenROADM/OpenROADM_MSA_Public/tree/master/model" --lint --prefix OpenROADM$version --rootdir "$TMP/openroadm-public/$version/" >>$LOG 2>&1) &
       PIDS2+=("$!")
       wait_for_processes "${PIDS2[@]}"
    done
@@ -156,7 +156,7 @@ if [ "$IS_PROD" = "True" ]; then
       slash_removed=${git%/}
       prefix=${slash_removed#*/}
       prefix2=$(echo $prefix | tr -cd '[:alnum:]')
-      (python yangGeneric.py --allinclusive True --metadata "Cisco $meta $prefix from https://github.com/YangModels/yang/tree/main/vendor/cisco/nx/$git" --lint True --prefix Cisco$os$prefix2 --rootdir "$path" >>$LOG 2>&1) &
+      (python yangGeneric.py --allinclusive True --metadata "Cisco $meta $prefix from https://github.com/YangModels/yang/tree/main/vendor/cisco/nx/$git" --lint --prefix Cisco$os$prefix2 --rootdir "$path" >>$LOG 2>&1) &
       PIDSNX+=("$!")
       wait_for_processes "${PIDSNX[@]}"
    done
@@ -177,7 +177,7 @@ if [ "$IS_PROD" = "True" ]; then
       slash_removed=${git%/}
       prefix=${slash_removed#*/}
       prefix2=$(echo $prefix | tr -cd '[:alnum:]')
-      (python yangGeneric.py --allinclusive True --metadata "Cisco $meta $prefix from https://github.com/YangModels/yang/tree/main/vendor/cisco/xe/$git" --lint True --prefix Cisco$os$prefix2 --rootdir "$path" >>$LOG 2>&1) &
+      (python yangGeneric.py --allinclusive True --metadata "Cisco $meta $prefix from https://github.com/YangModels/yang/tree/main/vendor/cisco/xe/$git" --lint --prefix Cisco$os$prefix2 --rootdir "$path" >>$LOG 2>&1) &
       PIDSXE+=("$!")
       wait_for_processes "${PIDSXE[@]}"
    done
@@ -198,7 +198,7 @@ if [ "$IS_PROD" = "True" ]; then
       slash_removed=${git%/}
       prefix=${slash_removed#*/}
       prefix2=$(echo $prefix | tr -cd '[:alnum:]')
-      (python yangGeneric.py --allinclusive True --metadata "Cisco $meta $prefix from https://github.com/YangModels/yang/tree/main/vendor/cisco/xr/$git" --lint True --prefix Cisco$os$prefix2 --rootdir "$path" >>$LOG 2>&1) &
+      (python yangGeneric.py --allinclusive True --metadata "Cisco $meta $prefix from https://github.com/YangModels/yang/tree/main/vendor/cisco/xr/$git" --lint --prefix Cisco$os$prefix2 --rootdir "$path" >>$LOG 2>&1) &
       PIDSXR+=("$!")
       wait_for_processes "${PIDSXR[@]}"
    done
@@ -219,7 +219,7 @@ if [ "$IS_PROD" = "True" ]; then
       slash_removed=${git%/}
       prefix=${slash_removed#*/}
       prefix2=$(echo $prefix | tr -cd '[:alnum:]')
-      (python yangGeneric.py --allinclusive True --metadata "Cisco $meta $prefix from https://github.com/YangModels/yang/tree/main/vendor/cisco/svo/$git" --lint True --prefix Cisco$os$prefix2 --rootdir "$path" >>$LOG 2>&1) &
+      (python yangGeneric.py --allinclusive True --metadata "Cisco $meta $prefix from https://github.com/YangModels/yang/tree/main/vendor/cisco/svo/$git" --lint --prefix Cisco$os$prefix2 --rootdir "$path" >>$LOG 2>&1) &
       PIDSSVO+=("$!")
       wait_for_processes "${PIDSSVO[@]}"
    done
@@ -242,7 +242,7 @@ if [ "$IS_PROD" = "True" ]; then
          slash_removed=${git%/}
          prefix=${slash_removed#*/}
          prefix2=$(echo $prefix | tr -cd '[:alnum:]')
-         python yangGeneric.py --allinclusive True --metadata "JUNIPER $prefix from https://github.com/Juniper/yang/tree/master/$git" --lint True --prefix Juniper$prefix2 --rootdir "$path" >>$LOG 2>&1
+         python yangGeneric.py --allinclusive True --metadata "JUNIPER $prefix from https://github.com/Juniper/yang/tree/master/$git" --lint --prefix Juniper$prefix2 --rootdir "$path" >>$LOG 2>&1
       # Juniper/15* does not exist
       elif [ $i -eq 15 ]; then
          continue
@@ -254,7 +254,7 @@ if [ "$IS_PROD" = "True" ]; then
                slash_removed=${git%/}
                prefix=${slash_removed#*/}
                prefix2=$(echo $prefix | tr -cd '[:alnum:]')
-               (python yangGeneric.py --allinclusive True --metadata "JUNIPER $prefix from https://github.com/Juniper/yang/tree/master/$git" --lint True --prefix Juniper$prefix2 --rootdir "$path2" >>$LOG 2>&1) &
+               (python yangGeneric.py --allinclusive True --metadata "JUNIPER $prefix from https://github.com/Juniper/yang/tree/master/$git" --lint --prefix Juniper$prefix2 --rootdir "$path2" >>$LOG 2>&1) &
                PIDJUNIPER+=("$!")
                wait_for_processes "${PIDJUNIPER[@]}"
             done
@@ -278,7 +278,7 @@ if [ "$IS_PROD" = "True" ]; then
          version=${slash_removed%/*}
          platform=${slash_removed#*/}
          prefix=$(echo $slash_removed | tr -cd '[:alnum:]')
-         (python yangGeneric.py --allinclusive True --metadata "HUAWEI ROUTER $version $platform https://github.com/Huawei/yang/tree/master/network-router/$git" --lint True --prefix NETWORKROUTER$prefix --rootdir "$path2" >>$LOG 2>&1) &
+         (python yangGeneric.py --allinclusive True --metadata "HUAWEI ROUTER $version $platform https://github.com/Huawei/yang/tree/master/network-router/$git" --lint --prefix NETWORKROUTER$prefix --rootdir "$path2" >>$LOG 2>&1) &
          PIDSHUAWEI+=("$!")
          wait_for_processes "${PIDSHUAWEI[@]}"
       done
@@ -290,7 +290,7 @@ if [ "$IS_PROD" = "True" ]; then
 
    # Ciena
    date +"%c: processing Ciena modules " >>$LOG
-   python yangGeneric.py --allinclusive True --metadata "Ciena https://github.com/YangModels/yang/tree/master/vendor/ciena" --lint True --prefix CIENA --rootdir "$NONIETFDIR/yangmodels/yang/vendor/ciena" >>$LOG 2>&1
+   python yangGeneric.py --allinclusive True --metadata "Ciena https://github.com/YangModels/yang/tree/master/vendor/ciena" --lint --prefix CIENA --rootdir "$NONIETFDIR/yangmodels/yang/vendor/ciena" >>$LOG 2>&1
 
    # Fujitsu
    date +"%c: processing Fujitsu modules " >>$LOG
@@ -302,7 +302,7 @@ if [ "$IS_PROD" = "True" ]; then
       yang_removed=${git%/*}
       prefix=${yang_removed#*/}
       prefix=$(echo $prefix | tr -cd '[:alnum:]')
-      (python yangGeneric.py --allinclusive True --metadata "Fujitsu https://github.com/FujitsuNetworkCommunications/FSS2-Yang/tree/master/$git" --lint True --prefix Fujitsu$prefix --rootdir "$path" >>$LOG 2>&1) &
+      (python yangGeneric.py --allinclusive True --metadata "Fujitsu https://github.com/FujitsuNetworkCommunications/FSS2-Yang/tree/master/$git" --lint --prefix Fujitsu$prefix --rootdir "$path" >>$LOG 2>&1) &
       PIDSFUJITSU+=("$!")
       wait_for_processes "${PIDSFUJITSU[@]}"
    done
@@ -322,7 +322,7 @@ if [ "$IS_PROD" = "True" ]; then
          slash_removed=${git%/}
          prefix=${slash_removed#*/}
          prefix=$(echo $prefix | tr -cd '[:alnum:]' | sed 's/latestsros//g')
-         (python yangGeneric.py --allinclusive True --metadata "Nokia $git https://github.com/nokia/7x50_YangModels/tree/master/$git" --lint True --prefix Nokia$prefix --rootdir "$path2" >>$LOG 2>&1) &
+         (python yangGeneric.py --allinclusive True --metadata "Nokia $git https://github.com/nokia/7x50_YangModels/tree/master/$git" --lint --prefix Nokia$prefix --rootdir "$path2" >>$LOG 2>&1) &
          PIDSNOKIA+=("$!")
          wait_for_processes "${PIDSNOKIA[@]}"
       done

--- a/bin/yang-exclude-bad-drafts.py
+++ b/bin/yang-exclude-bad-drafts.py
@@ -20,6 +20,9 @@ from create_config import create_config
 __author__ = 'bclaise@cisco.com'
 
 
+SOURCE = '/etc/yangcatalog/IETF-draft-list-with-no-YANG-problem.txt'
+
+
 def list_lines_from_file(f, debug_level):
     """
     Returns a list of all the lines in the file
@@ -90,11 +93,6 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description='Remove drafts well-known as having xym errors, '
                                                  'but that do not contain YANG models')
-    parser.add_argument('--source', 
-                        help='Full path to the file containing the drafts to be removed. '
-                             'Default is "/etc/yangcatalog/IETF-draft-list-with-no-YANG-problem.txt"',
-                        type=str,
-                        default= '/etc/yangcatalog/IETF-draft-list-with-no-YANG-problem.txt')
     parser.add_argument('--dstdir',
                         help='Directory from which to remove the drafts. '
                              'Default is "{}/my-id-mirror/"'.format(ietf_directory),
@@ -106,7 +104,7 @@ if __name__ == '__main__':
                         default=0)
     args = parser.parse_args()
     
-    ll = list_lines_from_file(args.source, args.debug)
+    ll = list_lines_from_file(SOURCE, args.debug)
     llasterix = replace_draft_version_by_asterix(ll, args.debug)
-    dir = os.path.dirname(args.source)
+    dir = os.path.dirname(SOURCE)
     remove_files(llasterix, args.dstdir, args.debug)

--- a/bin/yangGeneric.py
+++ b/bin/yangGeneric.py
@@ -251,8 +251,7 @@ if __name__ == '__main__':
                              'If set to "True", pyang --lint is run. '
                              'Otherwise, pyang --ietf is run. '
                              'Default is False',
-                        type=bool,
-                        default=False)
+                        action='store_true')
     parser.add_argument('--allinclusive',
                         help='Optional flag that determines whether the rootdir directory '
                              'contains all imported YANG modules; '

--- a/bin/yangGeneric.py
+++ b/bin/yangGeneric.py
@@ -251,7 +251,8 @@ if __name__ == '__main__':
                              'If set to "True", pyang --lint is run. '
                              'Otherwise, pyang --ietf is run. '
                              'Default is False',
-                        action='store_true')
+                        action='store_true',
+                        default=False)
     parser.add_argument('--allinclusive',
                         help='Optional flag that determines whether the rootdir directory '
                              'contains all imported YANG modules; '

--- a/bin/yangGetStats.py
+++ b/bin/yangGetStats.py
@@ -125,7 +125,7 @@ def list_of_ietf_draft_containing_keyword(drafts, keyword, draftpath, debug_leve
     list_of_ietf_draft_with_keyword = []
     for f in drafts:
         file_included = False
-        for line in open(draftpath + f, 'r', encoding='utf-8'):
+        for line in open(os.path.join(draftpath , f), 'r', encoding='utf-8'):
             if keyword in line.lower():
                 file_included = True
                 if debug_level > 0:
@@ -150,9 +150,9 @@ def write_dictionary_file_in_json(in_dict, path, file_name):
     :param file_name: The file name to be created
     :return: None
     """
-    with open(path + file_name, 'w', encoding='utf-8') as outfile:
+    with open(os.path.join(path, file_name), 'w', encoding='utf-8') as outfile:
         json.dump(in_dict, outfile, indent=2, sort_keys=True, separators=(',', ': '), ensure_ascii=True)
-    os.chmod(path + file_name, 0o664)
+    os.chmod(os.path.join(path, file_name), 0o664)
 
 
 # ----------------------------------------------------------------------

--- a/bin/yangGetStats.py
+++ b/bin/yangGetStats.py
@@ -164,33 +164,16 @@ if __name__ == '__main__':
     backup_directory = config.get('Directory-Section', 'backup') + '/'
     ietf_directory = config.get('Directory-Section', 'ietf-directory')
 
+    draft_path_strict = os.path.join(ietf_directory, 'draft-with-YANG-strict')
+    draft_path_nostrict = os.path.join(ietf_directory, 'draft-with-YANG-no-strict')
+    draft_path_diff = os.path.join(ietf_directory, 'draft-with-YANG-diff')
+    stats_path = os.path.join(web_private, 'stats')
+
     parser = argparse.ArgumentParser(description='YANG Stats Extractor')
     parser.add_argument('--days',
                         help='Numbers of days to get back in history. Default is -1 = unlimited',
                         type=int,
                         default=-1)
-    parser.add_argument('--draftpathstrict',
-                        help='Path to the directory where the drafts containing the YANG model(s) are stored - '
-                        'with xym flag strict=True. '
-                        'Default is "{}/draft-with-YANG-strict/"'.format(ietf_directory),
-                        type=str,
-                        default='{}/draft-with-YANG-strict/'.format(ietf_directory))
-    parser.add_argument('--draftpathnostrict',
-                        help='Path to the directory where the drafts containing the YANG model(s) are stored - '
-                        'with xym flag strict=False. '
-                        'Default is "{}/draft-with-YANG-no-strict/"'.format(ietf_directory),
-                        type=str,
-                        default='{}/draft-with-YANG-no-strict/'.format(ietf_directory))
-    parser.add_argument('--draftpathdiff',
-                        help='Path to the directory where IETF drafts containing YANG model(s), diff from flag = True and False. '
-                             'Default is "{}/draft-with-YANG-diff/"'.format(ietf_directory),
-                        type=str,
-                        default='{}/draft-with-YANG-diff/'.format(ietf_directory))
-    parser.add_argument('--statspath',
-                        help='Path to the directory where stat files are stored. '
-                             'Default is "{}/stats/"'.format(web_private),
-                        type=str,
-                        default='{}/stats/'.format(web_private))
     parser.add_argument('--debug',
                         help='Debug level - default is 0',
                         type=int,
@@ -263,7 +246,7 @@ if __name__ == '__main__':
     if int(args.days) == -1:
         with open(json_history_file, 'w') as f:
             json.dump(yangPageCompilationStats, f)
-        write_dictionary_file_in_json(yangPageCompilationStats, args.statspath, "YANGPageMainStats.json")
+        write_dictionary_file_in_json(yangPageCompilationStats, stats_path, "YANGPageMainStats.json")
 
     prefix = "IETFYANGPageMain_"
     json_history_file = '{}/{}history.json'.format(backup_directory, prefix)
@@ -315,7 +298,7 @@ if __name__ == '__main__':
     if int(args.days) == -1:
         with open(json_history_file, 'w') as f:
             json.dump(yangPageCompilationStats, f)
-        write_dictionary_file_in_json(yangPageCompilationStats, args.statspath, "IETFYANGPageMainStats.json")
+        write_dictionary_file_in_json(yangPageCompilationStats, stats_path, "IETFYANGPageMainStats.json")
 
     backup_prefix = ['HydrogenODLPageCompilation_', 'HeliumODLPageCompilation_',
                      'LithiumODLPageCompilation_', 'IETFCiscoAuthorsYANGPageCompilation_',
@@ -374,12 +357,12 @@ if __name__ == '__main__':
             if prefix == "IETFDraftYANGPageCompilation_":
                 with open(json_history_file, 'w') as f:
                     json.dump(yangPageCompilationStats, f)
-                write_dictionary_file_in_json(yangPageCompilationStats, args.statspath,
+                write_dictionary_file_in_json(yangPageCompilationStats, stats_path,
                                               "IETFYANGPageCompilationStats.json")
             else:
                 with open(json_history_file, 'w') as f:
                     json.dump(yangPageCompilationStats, f)
-                write_dictionary_file_in_json(yangPageCompilationStats, args.statspath,
+                write_dictionary_file_in_json(yangPageCompilationStats, stats_path,
                                               "{}Stats.json".format(prefix[:-1]))
 
     # Print the number of RFCs per date, and store the info into a json file
@@ -417,12 +400,12 @@ if __name__ == '__main__':
     if int(args.days) == -1:
         with open(json_history_file, 'w') as f:
             json.dump(yangPageCompilationStats, f)
-        write_dictionary_file_in_json(yangPageCompilationStats, args.statspath, "IETFYANGOutOfRFCStats.json")
+        write_dictionary_file_in_json(yangPageCompilationStats, stats_path, "IETFYANGOutOfRFCStats.json")
 
     # determine the number of company authored drafts
-    files = [f for f in os.listdir(args.draftpathstrict) if os.path.isfile(os.path.join(args.draftpathstrict, f))]
-    files_no_strict = [f for f in os.listdir(args.draftpathnostrict) if
-                       os.path.isfile(os.path.join(args.draftpathnostrict, f))]
+    files = [f for f in os.listdir(draft_path_strict) if os.path.isfile(os.path.join(draft_path_strict, f))]
+    files_no_strict = [f for f in os.listdir(draft_path_nostrict) if
+                       os.path.isfile(os.path.join(draft_path_nostrict, f))]
     total_number_drafts = len(files)
     total_number_drafts_no_strict = len(files_no_strict)
 
@@ -463,9 +446,9 @@ if __name__ == '__main__':
         if not name and not domain:
             print()
         else:
-            strict = len(list_of_ietf_draft_containing_keyword(files, domain, args.draftpathstrict, debug_level))
+            strict = len(list_of_ietf_draft_containing_keyword(files, domain, draft_path_strict, debug_level))
             non_strict = len(list_of_ietf_draft_containing_keyword(files_no_strict, domain,
-                                                                   args.draftpathnostrict, debug_level))
+                                                                   draft_path_nostrict, debug_level))
             print('{}: {} - non strict rules: {}'.format(name, strict, non_strict))
 
     print()
@@ -489,7 +472,7 @@ if __name__ == '__main__':
     for f in files_no_strict:
         if f not in files:
             files_diff.append(f)
-            bash_command = "cp " + args.draftpathnostrict + f + " " + args.draftpathdiff
+            bash_command = "cp " + draft_path_nostrict + f + " " + draft_path_diff
             temp_result = os.popen(bash_command).read()
             if debug_level > 0:
                 print(

--- a/bin/yangIetf.py
+++ b/bin/yangIetf.py
@@ -79,7 +79,7 @@ if __name__ == '__main__':
     parser.add_argument('--archived',
                         help='Extract expired drafts as well',
                         action='store_true',
-                        default='{}/my-id-mirror/'.format(ietf_directory))
+                        default=False)
     parser.add_argument('--yangpath',
                         help='Path to the directory where to extract models (only correct). '
                              'Default is "{}/YANG/"'.format(ietf_directory),
@@ -145,7 +145,8 @@ if __name__ == '__main__':
                         help='Optional flag that determines wheter compilation should be run '
                              'for all files even if they have not been changed '
                              'or even if the validators versions have not been changed.',
-                        action='store_true')
+                        action='store_true',
+                        default=False)
 
     args = parser.parse_args()
     if args.archived:

--- a/bin/yangIetf.py
+++ b/bin/yangIetf.py
@@ -21,7 +21,6 @@ import argparse
 import datetime
 import json
 import os
-from operator import itemgetter
 
 import requests
 
@@ -72,73 +71,67 @@ if __name__ == '__main__':
     api_ip = config.get('Web-Section', 'ip')
     protocol = config.get('Web-Section', 'protocol-api')
     resutl_html_dir = config.get('Web-Section', 'result-html-dir')
+    draft_path = config.get('Directory-Section', 'ietf-drafts')
+    rfc_path = config.get('Directory-Section', 'ietf-rfcs')
 
     parser = argparse.ArgumentParser(description='YANG RFC/Draft Processor')
-    parser.add_argument('--draftpath',
-                        help='Path to the directory where all the drafts will be stored. '
-                             'Default is {}/my-id-mirror/ '
-                             'To get expired drafts as well, use {}/my-id-archive-mirror/'
-                             .format(ietf_directory, ietf_directory),
-                        type=str,
+    parser.add_argument('--archived',
+                        help='Extract expired drafts as well',
+                        action='store_true',
                         default='{}/my-id-mirror/'.format(ietf_directory))
-    parser.add_argument('--rfcpath',
-                        help='Path to the directory where all the RFCs will be stored. '
-                             'Default is {}/rfc/'.format(ietf_directory),
-                        type=str,
-                        default='{}/rfc/'.format(ietf_directory))
     parser.add_argument('--yangpath',
-                        help='Path to the directory where extracted models will be stored (only correct). '
+                        help='Path to the directory where to extract models (only correct). '
                              'Default is "{}/YANG/"'.format(ietf_directory),
                         type=str,
                         default='{}/YANG/'.format(ietf_directory))
     parser.add_argument('--allyangpath',
-                        help='Path to the directory where extracted models will be stored (including bad ones). '
+                        help='Path to the directory where to extract models (including bad ones). '
                              'Default is "{}/YANG-all/"'.format(ietf_directory),
                         type=str,
                         default='{}/YANG-all/'.format(ietf_directory))
     parser.add_argument('--allyangexamplepath',
-                        help='Path to the directory where extracted example models will be stored '
+                        help='Path to the directory where to extract example models '
                         '(starting with example- and not with CODE BEGINS/END). '
                         'Default is "{}/YANG-example/"'.format(ietf_directory),
                         type=str,
                         default='{}/YANG-example/'.format(ietf_directory))
     parser.add_argument('--yangexampleoldrfcpath',
-                        help='Directory where to store '
+                        help='Path to the directory where to extract '
                              'the hardcoded YANG module example models from old RFCs (not starting with example-). '
                              'Default is "{}/YANG-example-old-rfc/"'.format(ietf_directory),
                         type=str,
                         default='{}/YANG-example-old-rfc/'.format(ietf_directory))
     parser.add_argument('--draftpathstrict',
-                        help='Path to the directory where the drafts containing the YANG model(s) are stored - '
+                        help='Path to the directory where to extract the drafts containing the YANG model(s) - '
                         'with xym flag strict=True. '
                         'Default is "{}/draft-with-YANG-strict/"'.format(ietf_directory),
                         type=str,
                         default='{}/draft-with-YANG-strict/'.format(ietf_directory))
     parser.add_argument('--draftpathnostrict',
-                        help='Path to the directory where the drafts containing the YANG model(s) are stored - '
+                        help='Path to the directory where to extract the drafts containing the YANG model(s) - '
                         'with xym flag strict=False. '
                         'Default is "{}/draft-with-YANG-no-strict/"'.format(ietf_directory),
                         type=str,
                         default='{}/draft-with-YANG-no-strict/'.format(ietf_directory))
     parser.add_argument('--draftpathonlyexample',
-                        help='Path to the directory where the drafts containing examples are stored -'
+                        help='Path to the directory where to extract the drafts containing examples -'
                         'with xym flags strict=False and strict_examples=True. '
                         'Default is "{}/draft-with-YANG-example/"'.format(ietf_directory),
                         type=str,
                         default='{}/draft-with-YANG-example/'.format(ietf_directory))
     parser.add_argument('--rfcyangpath',
-                        help='Directory where to store the data models extracted from RFCs. '
+                        help='Path to the directory where to extract the data models extracted from RFCs. '
                              'Default is "{}/YANG-rfc/"'.format(ietf_directory),
                         type=str,
                         default='{}/YANG-rfc/'.format(ietf_directory))
     parser.add_argument('--rfcextractionyangpath',
-                        help='Directory where to store '
+                        help='Path to the directory where to extract '
                              'the typedef, grouping, identity from data models extracted from RFCs. '
                              'Default is "{}/YANG-rfc-extraction/"'.format(ietf_directory),
                         type=str,
                         default='{}/YANG-rfc-extraction/'.format(ietf_directory))
     parser.add_argument('--draftelementspath',
-                        help='Directory where to store '
+                        help='Path to the directory where to extract '
                              'the typedef, grouping, identity from data models correctely extracted from drafts. '
                              'Default is "{}/draft-elements/"'.format(ietf_directory),
                         type=str,
@@ -151,11 +144,12 @@ if __name__ == '__main__':
                         help='Optional flag that determines wheter compilation should be run '
                              'for all files even if they have not been changed '
                              'or even if the validators versions have not been changed.',
-                        type=bool,
-                        default=False)
+                        action='store_true')
 
     args = parser.parse_args()
-    custom_print('Start of yangIetf.py job in {}'.format(args.draftpath))
+    if args.archived:
+        draft_path = os.path.join(ietf_directory, 'my-id-archive-mirror')
+    custom_print('Start of yangIetf.py job in {}'.format(draft_path))
     debug_level = args.debug
 
     # Initialize files generator -> used in creating JSON/HTML results files
@@ -180,7 +174,7 @@ if __name__ == '__main__':
         all_yang_catalog_metadata[key] = mod
 
     draft_extractor_paths = {
-        'draft_path': args.draftpath,
+        'draft_path': draft_path,
         'yang_path': args.yangpath,
         'draft_elements_path': args.draftelementspath,
         'draft_path_strict': args.draftpathstrict,
@@ -207,7 +201,7 @@ if __name__ == '__main__':
     # ----------------------------------------------------------------------
     # Extract YANG models from IETF RFCs files
     # ----------------------------------------------------------------------
-    rfcExtractor = RFCExtractor(args.rfcpath, args.rfcyangpath, args.rfcextractionyangpath, args.debug)
+    rfcExtractor = RFCExtractor(rfc_path, args.rfcyangpath, args.rfcextractionyangpath, args.debug)
     rfcExtractor.extract_rfcs()
     rfcExtractor.invert_dict()
     rfcExtractor.remove_invalid_files()
@@ -276,7 +270,7 @@ if __name__ == '__main__':
     # Compile modules extracted from drafts
     # ----------------------------------------------------------------------
     paths = {
-        'draftpath': args.draftpath,
+        'draftpath': draft_path,
         'rfcpath': args.rfcyangpath
     }
     custom_print('Starting compilation in {} directory'.format(args.yangpath))

--- a/bin/yangVersion11.py
+++ b/bin/yangVersion11.py
@@ -27,51 +27,25 @@ __license__ = "Apache v2.0"
 __email__ = "bclaise@cisco.com"
 
 
-def YANGversion11(srcpath, rfcpath, YANGmodel, yangpath, test, debug):
+def YANGversion11(src_path, dest_path, debug):
     """
     YANG 1.1 Processing Tool.
     This is the main (external) API entry for the module.
-    if the test argument is True, the function tests whether a module is YANG 1.1\
-    if the test arugment is False, the functions copies all YANG 1.1 modules to a yangpath
-    :param srcpath: The optional directory where to find the source YANG data models
-    :param rfcpath: The optional directory where to find the source RFC-produced YANG data models
-    :param YANGmodel: A specific YANG model, to be tested for YANG version 1.1 compliance, with the --test option
-    :param yangpath: The path to store the version 1.1 YANG data models
+    The functions copies all YANG 1.1 modules to a yangpath
+    :param src_path: The optional directory where to find the source YANG data models
+    :param dest_path: The path to store the version 1.1 YANG data models
     :param debug: Determines how much debug output is printed to the console
-    :return: True/False with the --test. Return None otherwise
     """ 
-    # test action
-    if debug > 0:
-        print("Should I do the test?: " + str(test))
-    # bug: whatever I enter in 'script --test' results in True
-    if test is True:
-        if YANGmodel == "":
-            print("   --test MUST be used with the -- YANGmodel filename option.")
-            return False
-        else:
-            print("we're good")
-            bash_command = "grep yang-version " + srcpath  + YANGmodel + " | grep 1.1"
-            temp_result = os.popen(bash_command).read()
-            if debug > 0:
-                print("bash command: " + bash_command)
-            if "1.1" in temp_result :
-                if debug > 0:
-                    print("DEBUG: " + YANGmodel + " is version 1.1 ")
-                return True
-            else:
-                if debug > 0:
-                    print("DEBUG: " + YANGmodel + " is NOT version 1.1 ")
-                return False
 
     if debug > 0:
         print("No test condition")
     
-    remove_directory_content(yangpath, debug)
-    yang_model_list = [f for f in os.listdir(srcpath) if os.path.isfile(os.path.join(srcpath, f))]
+    remove_directory_content(dest_path, debug)
+    yang_model_list = [f for f in os.listdir(src_path) if os.path.isfile(os.path.join(src_path, f))]
     yang_model_list_v11 = []
     
     for yang_model in yang_model_list:      
-        bash_command = "grep yang-version " + srcpath  + yang_model + " | grep 1.1"
+        bash_command = "grep yang-version " + src_path  + yang_model + " | grep 1.1"
         if debug > 0:
             print("bash command: " + bash_command)
         temp_result = os.popen(bash_command).read()
@@ -80,7 +54,7 @@ def YANGversion11(srcpath, rfcpath, YANGmodel, yangpath, test, debug):
                 print("DEBUG: " + yang_model + " is version 1.1 ")
             yang_model_list_v11.append(yang_model)
             # copy function below could be improved with python command, as opposed to a bash
-            bash_command = "cp  " + srcpath + "/" + yang_model + " " + yangpath + "/" + yang_model
+            bash_command = "cp  " + src_path + "/" + yang_model + " " + dest_path + "/" + yang_model
             temp_result = os.popen(bash_command).read()
     if debug > 0:
         print("DEBUG: YANG Model list with YANG version 1.1: " )
@@ -99,33 +73,14 @@ if __name__ == '__main__':
     config = create_config()
     ietf_directory = config.get('Directory-Section', 'ietf-directory')
 
-    parser = argparse.ArgumentParser(description='YANG 1.1 Processing Tool. Either test if a YANG module is YANG 1.1 (test option), or copy all YANG 1.1 modules to yangpath')
-    parser.add_argument('--srcpath',
-                        help='Directory where to find the source YANG data models. '
-                             'Default is "{}/YANG/"'.format(ietf_directory),
-                        type=str,
-                        default='{}/YANG/'.format(ietf_directory))
-    parser.add_argument('--rfcpath',
-                        help='Path to the directory where all the RFCs will be stored. '
-                             'Default is "{}/rfc/"'.format(ietf_directory),
-                        type=str,
-                        default='{}/rfc/'.format(ietf_directory))
-    parser.add_argument('--YANGmodule',
-                        help='A specific YANG module, to be tested for YANG version 1.1 compliance, with the --test option',
-                        type=str,
-                        default='')
-    parser.add_argument('--yangpath',
+    src_path = os.path.join(ietf_directory, 'YANG')
+
+    parser = argparse.ArgumentParser(description='YANG 1.1 Processing Tool. Copy all YANG 1.1 modules to destpath')
+    parser.add_argument('--destpath',
                         help='Path to store the version 1.1 YANG data models. '
                              'Default is "{}/YANG-v11/"'.format(ietf_directory),
                         type=str,
                         default='{}/YANG-v11/'.format(ietf_directory))
-    # Following should be improve so that we don't need to enter a boolean
-    # bug: whatever I enter in 'script --test' results in True
-    parser.add_argument('--test',
-                        help='Test whether a YANG data model is based on version 1.1. '
-                             'If this is the case, return "true"',
-                        type=bool,
-                        default=False)
     parser.add_argument('--debug',
                         help='Debug level - default is 0',
                         type=int,
@@ -133,4 +88,4 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
         
-    YANGversion11(args.srcpath, args.rfcpath, args.YANGmodule, args.yangpath, args.test, args.debug)
+    YANGversion11(src_path, args.destpath,args.debug)

--- a/bin/yangVersion11.py
+++ b/bin/yangVersion11.py
@@ -44,8 +44,8 @@ def YANGversion11(src_path, dest_path, debug):
     yang_model_list = [f for f in os.listdir(src_path) if os.path.isfile(os.path.join(src_path, f))]
     yang_model_list_v11 = []
     
-    for yang_model in yang_model_list:      
-        bash_command = "grep yang-version " + src_path  + yang_model + " | grep 1.1"
+    for yang_model in yang_model_list:
+        bash_command = "grep yang-version {} | grep 1.1".format(os.path.join(src_path, yang_model) )
         if debug > 0:
             print("bash command: " + bash_command)
         temp_result = os.popen(bash_command).read()
@@ -54,7 +54,7 @@ def YANGversion11(src_path, dest_path, debug):
                 print("DEBUG: " + yang_model + " is version 1.1 ")
             yang_model_list_v11.append(yang_model)
             # copy function below could be improved with python command, as opposed to a bash
-            bash_command = "cp  " + src_path + "/" + yang_model + " " + dest_path + "/" + yang_model
+            bash_command = "cp  {} {}".format(os.path.join(src_path, yang_model), os.path.join(dest_path, yang_model))
             temp_result = os.popen(bash_command).read()
     if debug > 0:
         print("DEBUG: YANG Model list with YANG version 1.1: " )


### PR DESCRIPTION
Remove script options which are currently
unused and unlikely to be used in the future.
Pull the paths to ietf drafts and rfcs from
the `ietf-drafts` and `ietf-rfcs` config
options respectively.