### PR TITLE
Repeated cloning and deleting of openconfig repo canceled

### DIFF
--- a/bin/runIETFstats.sh
+++ b/bin/runIETFstats.sh
@@ -100,7 +100,7 @@ ln -f -s $NONIETFDIR/yangmodels/yang/standard/ieee/published/802.11/ $MODULES/ie
 rm -f $MODULES/mef
 ln -f -s $NONIETFDIR/mef/YANG-public/src/model/standard/ $MODULES/mef
 rm -f $MODULES/openconfig-main
-ln -f -s $NONIETFDIR/openconfig/public/release/models/ $MODULES/openconfig-main
+ln -f -s $NONIETFDIR/openconfig-flat/public/release/models/ $MODULES/openconfig-main
 rm -f $MODULES/iana
 ln -f -s $NONIETFDIR/yangmodels/yang/standard/iana/ $MODULES/iana
 

--- a/bin/runYANGgenericstats.sh
+++ b/bin/runYANGgenericstats.sh
@@ -67,7 +67,7 @@ PIDS+=("$!")
 PIDS+=("$!")
 
 # Experimental IEEE
-(python $BIN/yangGeneric.py --metadata "IEEE: Draft YANG Data Models compilation from https://github.com/YangModels/yang/tree/master/experimental/ieee: The 'experimental/ieee' branch is intended for IEEE work that does not yet have a Project Authorization Request (PAR)." --lint --prefix IEEEExperimental --rootdir "$NONIETFDIR/yangmodels/yang/experimental/ieee/" --forcecompilation True >>$LOG 2>&1) &
+(python $BIN/yangGeneric.py --metadata "IEEE: Draft YANG Data Models compilation from https://github.com/YangModels/yang/tree/master/experimental/ieee: The 'experimental/ieee' branch is intended for IEEE work that does not yet have a Project Authorization Request (PAR)." --lint --prefix IEEEExperimental --rootdir "$NONIETFDIR/yangmodels/yang/experimental/ieee/" >>$LOG 2>&1) &
 PIDS+=("$!")
 
 # Standard IANA

--- a/bin/rundownloadgithub.sh
+++ b/bin/rundownloadgithub.sh
@@ -39,30 +39,20 @@ git submodule update --init --recursive >>$LOG 2>&1
 
 # get the entire content of github (openconfig)
 mkdir -p $NONIETFDIR/openconfig
-if [ ! -d $NONIETFDIR/openconfig/yang ]; then
-	cd $NONIETFDIR/openconfig
-	git clone --recurse-submodules https://github.com/openconfig/yang.git >>$LOG 2>&1
-fi
-cd $NONIETFDIR/openconfig/yang
-git init >>$LOG 2>&1
-git pull --recurse-submodules https://github.com/openconfig/yang.git >>$LOG 2>&1
-
-#
-# A lot of ugly things here... including a 'clone' rather than a 'pull' which does not work as file structure is changed
-#
-
 cd $NONIETFDIR/openconfig
-rm -rf public
-git clone --recurse-submodules https://github.com/openconfig/public.git >>$LOG 2>&1
+if [ ! -d $NONIETFDIR/openconfig/public ]; then
+	git clone --recurse-submodules https://github.com/openconfig/public.git >>$LOG 2>&1
+fi
+cd $NONIETFDIR/openconfig/public
+git pull --recurse-submodules https://github.com/openconfig/public.git >>$LOG 2>&1
 
-# the trick below is "flatten" all .yang files from subdirectories into one directory, to avoid the confd path issues. The old structure has been removed
-# TODO check for overwrite errors !!!
-mkdir -p $NONIETFDIR/openconfig/public/release/models-flat
+# Trick below is "flatten" all .yang files from subdirectories into one directory, to avoid the ConfD path issues
 cd $NONIETFDIR/openconfig/public/release/models
-find . -name "*.yang" -exec cp -t $NONIETFDIR/openconfig/public/release/models-flat/ {} + >>$LOG 2>&1
-cd ..
-rm -rf $NONIETFDIR/openconfig/public/release/models
-mv $NONIETFDIR/openconfig/public/release/models-flat $NONIETFDIR/openconfig/public/release/models
+if [ -d $NONIETFDIR/openconfig-flat/public/release/models ]; then
+	rm -rf $NONIETFDIR/openconfig-flat/public/release/models
+fi
+mkdir -p $NONIETFDIR/openconfig-flat/public/release/models
+find . -name "*.yang" -exec cp -t $NONIETFDIR/openconfig-flat/public/release/models/ {} + >>$LOG 2>&1
 
 # get the entire content of github (sysrepo)
 mkdir -p $NONIETFDIR/sysrepo


### PR DESCRIPTION
- openconfig/public repository will be only pulled now
- flattened structure will be created every time by copying yang files
from up-to-date repository

Signed-off-by: Slavomir Mazur <slavomir.mazur@pantheon.tech>