### PR TITLE
chore: rename push_to_confd() -> push_to_redis()

### DIFF
--- a/bin/compilators/draftsCompilator.py
+++ b/bin/compilators/draftsCompilator.py
@@ -28,7 +28,7 @@ from parsers.pyangParser import PyangParser
 from parsers.yangdumpProParser import YangdumpProParser
 from parsers.yanglintParser import YanglintParser
 from utility.utility import (check_yangcatalog_data, module_or_submodule,
-                             push_to_confd)
+                             push_to_redis)
 from versions import ValidatorsVersions
 
 
@@ -121,7 +121,7 @@ class DraftsCompilator:
                                            compilation_status, compilation_results, all_yang_catalog_metadata, is_rfc,
                                            versions, 'ietf-draft'))
                 if len(updated_modules) > 100:
-                    updated_modules = push_to_confd(updated_modules, self.config)
+                    updated_modules = push_to_redis(updated_modules, self.config)
                 yang_file_compilation = [draft_url_anchor, email_anchor, yang_model_anchor, compilation_status,
                                          result_pyang, result_no_ietf_flag, result_confd, result_yuma, result_yanglint]
                 yang_file_compilation_authors = [draft_url_anchor, email_anchor, cisco_email_anchor, yang_model_anchor,
@@ -139,7 +139,7 @@ class DraftsCompilator:
                 self.results_no_submodules_dict[yang_file] = yang_file_compilation
                 self.results_no_submodules_dict_authors[yang_file] = yang_file_compilation
 
-        updated_modules = push_to_confd(updated_modules, self.config)
+        updated_modules = push_to_redis(updated_modules, self.config)
         # Update files content hashes and dump into .json file
         if len(fileHasher.updated_hashes) > 0:
             fileHasher.dump_hashed_files_list(fileHasher.updated_hashes)

--- a/bin/compilators/examplesCompilator.py
+++ b/bin/compilators/examplesCompilator.py
@@ -24,7 +24,7 @@ from create_config import create_config
 from fileHasher import FileHasher
 from parsers.pyangParser import PyangParser
 from utility.utility import (check_yangcatalog_data, module_or_submodule,
-                             push_to_confd)
+                             push_to_redis)
 from versions import ValidatorsVersions
 
 
@@ -92,7 +92,7 @@ class ExamplesCompilator:
                                            compilation_status, compilation_results, all_yang_catalog_metadata, False,
                                            versions, 'ietf-example'))
                 if len(updated_modules) > 100:
-                    updated_modules = push_to_confd(updated_modules, self.config)
+                    updated_modules = push_to_redis(updated_modules, self.config)
                 yang_file_compilation = [draft_url_anchor, email_anchor, compilation_status, pyang_result, pyang_result_no_ietf_flag]
 
                 # Do not store hash if compilation result is 'UNKNOWN' -> try to parse model again next time
@@ -103,7 +103,7 @@ class ExamplesCompilator:
             if module_or_submodule(yang_file_path) == 'module':
                 self.results_no_submodules_dict[yang_file] = yang_file_compilation
 
-        updated_modules = push_to_confd(updated_modules, self.config)
+        updated_modules = push_to_redis(updated_modules, self.config)
         # Update files content hashes and dump into .json file
         if len(fileHasher.updated_hashes) > 0:
             fileHasher.dump_hashed_files_list(fileHasher.updated_hashes)

--- a/bin/compilators/rfcsCompilator.py
+++ b/bin/compilators/rfcsCompilator.py
@@ -23,7 +23,7 @@ import os
 from create_config import create_config
 from fileHasher import FileHasher
 from utility.utility import (check_yangcatalog_data, module_or_submodule,
-                             push_to_confd)
+                             push_to_redis)
 from versions import ValidatorsVersions
 
 
@@ -69,14 +69,14 @@ class RfcsCompilator:
                     check_yangcatalog_data(self.config, yang_file_path, datatracker_url, document_name, mailto,
                                            compilation_status, {}, all_yang_catalog_metadata, True, versions, 'ietf-rfc'))
                 if len(updated_modules) > 100:
-                    updated_modules = push_to_confd(updated_modules, self.config)
+                    updated_modules = push_to_redis(updated_modules, self.config)
                 fileHasher.updated_hashes[yang_file_path] = file_hash
 
             self.results_dict[yang_file] = rfc_url_anchor
             if module_or_submodule(yang_file_path) == 'module':
                 self.results_no_submodules_dict[yang_file] = rfc_url_anchor
 
-        updated_modules = push_to_confd(updated_modules, self.config)
+        updated_modules = push_to_redis(updated_modules, self.config)
         # Update files content hashes and dump into .json file
         if len(fileHasher.updated_hashes) > 0:
             fileHasher.dump_hashed_files_list(fileHasher.updated_hashes)

--- a/bin/utility/utility.py
+++ b/bin/utility/utility.py
@@ -30,7 +30,7 @@ from redisConnections.redisConnection import RedisConnection
 from utility.staticVariables import IETF_RFC_MAP
 
 
-def push_to_confd(updated_modules: list, config: configparser.ConfigParser):
+def push_to_redis(updated_modules: list, config: configparser.ConfigParser):
     json_modules_data = json.dumps({'modules': {'module': updated_modules}})
     credentials = config.get('Secrets-Section', 'confd-credentials').strip('"').split()
     confd_prefix = config.get('Web-Section', 'confd-prefix')

--- a/bin/yangGeneric.py
+++ b/bin/yangGeneric.py
@@ -30,7 +30,7 @@ from parsers.yangdumpProParser import YangdumpProParser
 from parsers.yanglintParser import YanglintParser
 from utility.utility import (check_yangcatalog_data, dict_to_list,
                              list_br_html_addition, module_or_submodule,
-                             number_that_passed_compilation, push_to_confd)
+                             number_that_passed_compilation, push_to_redis)
 from versions import ValidatorsVersions
 
 __author__ = 'Benoit Claise'
@@ -350,7 +350,7 @@ if __name__ == '__main__':
             yang_file_compilation = [
                 compilation_status, result_pyang, result_no_pyang_param, result_confd, result_yuma, result_yanglint]
             if len(updated_modules) > 100:
-                updated_modules = push_to_confd(updated_modules, config)
+                updated_modules = push_to_redis(updated_modules, config)
 
             # Do not store hash if compilation_status is 'UNKNOWN' -> try to parse model again next time
             if compilation_status != 'UNKNOWN':
@@ -404,7 +404,7 @@ if __name__ == '__main__':
                 if counter == 0:
                     break
 
-    push_to_confd(updated_modules, config)
+    push_to_redis(updated_modules, config)
 
     # Print the summary of the compilation results
     print('--------------------------')


### PR DESCRIPTION
Confd is no longer used as a datastore.