### PR TITLE
chore: add bin directory to pyright extra paths

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,3 +1,3 @@
 {
-    "extraPaths": ["./bin/resources/HTML"]
+    "extraPaths": ["./bin/resources/HTML", "./bin"]
 }


### PR DESCRIPTION
This lets us access modules from e.g. test files without the bin
prefix.