### PR TITLE
Notify authors of ietf drafts

### DIFF
--- a/bin/extract_ietf_modules.py
+++ b/bin/extract_ietf_modules.py
@@ -33,8 +33,8 @@ from remove_directory_content import remove_directory_content
 
 
 def custom_print(message: str):
-    timestamp = '{} ({}):'.format(datetime.datetime.now().time(), os.getpid())
-    print('{} {}'.format(timestamp, message), flush=True)
+    timestamp = f'{datetime.datetime.now().time()} ({os.getpid()}):'
+    print(f'{timestamp} {message}', flush=True)
 
 
 # ----------------------------------------------------------------------
@@ -55,61 +55,61 @@ def main():
                         default=False)
     parser.add_argument('--yangpath',
                         help='Path to the directory where to extract models (only correct). '
-                             'Default is "{}/YANG/"'.format(ietf_directory),
+                             f'Default is "{ietf_directory}/YANG/"',
                         type=str,
-                        default='{}/YANG/'.format(ietf_directory))
+                        default=f'{ietf_directory}/YANG/')
     parser.add_argument('--allyangpath',
                         help='Path to the directory where to extract models (including bad ones). '
-                             'Default is "{}/YANG-all/"'.format(ietf_directory),
+                             f'Default is "{ietf_directory}/YANG-all/"',
                         type=str,
-                        default='{}/YANG-all/'.format(ietf_directory))
+                        default=f'{ietf_directory}/YANG-all/')
     parser.add_argument('--allyangexamplepath',
                         help='Path to the directory where to extract example models '
                         '(starting with example- and not with CODE BEGINS/END). '
-                        'Default is "{}/YANG-example/"'.format(ietf_directory),
+                        f'Default is "{ietf_directory}/YANG-example/"',
                         type=str,
-                        default='{}/YANG-example/'.format(ietf_directory))
+                        default=f'{ietf_directory}/YANG-example/')
     parser.add_argument('--yangexampleoldrfcpath',
                         help='Path to the directory where to extract '
                              'the hardcoded YANG module example models from old RFCs (not starting with example-). '
-                             'Default is "{}/YANG-example-old-rfc/"'.format(ietf_directory),
+                             f'Default is "{ietf_directory}/YANG-example-old-rfc/"',
                         type=str,
-                        default='{}/YANG-example-old-rfc/'.format(ietf_directory))
+                        default=f'{ietf_directory}/YANG-example-old-rfc/')
     parser.add_argument('--draftpathstrict',
                         help='Path to the directory where to extract the drafts containing the YANG model(s) - '
                         'with xym flag strict=True. '
-                        'Default is "{}/draft-with-YANG-strict/"'.format(ietf_directory),
+                        f'Default is "{ietf_directory}/draft-with-YANG-strict/"',
                         type=str,
-                        default='{}/draft-with-YANG-strict/'.format(ietf_directory))
+                        default=f'{ietf_directory}/draft-with-YANG-strict/')
     parser.add_argument('--draftpathnostrict',
                         help='Path to the directory where to extract the drafts containing the YANG model(s) - '
                         'with xym flag strict=False. '
-                        'Default is "{}/draft-with-YANG-no-strict/"'.format(ietf_directory),
+                        f'Default is "{ietf_directory}/draft-with-YANG-no-strict/"',
                         type=str,
-                        default='{}/draft-with-YANG-no-strict/'.format(ietf_directory))
+                        default=f'{ietf_directory}/draft-with-YANG-no-strict/')
     parser.add_argument('--draftpathonlyexample',
                         help='Path to the directory where to extract the drafts containing examples -'
                         'with xym flags strict=False and strict_examples=True. '
-                        'Default is "{}/draft-with-YANG-example/"'.format(ietf_directory),
+                        f'Default is "{ietf_directory}/draft-with-YANG-example/"',
                         type=str,
-                        default='{}/draft-with-YANG-example/'.format(ietf_directory))
+                        default=f'{ietf_directory}/draft-with-YANG-example/')
     parser.add_argument('--rfcyangpath',
                         help='Path to the directory where to extract the data models extracted from RFCs. '
-                             'Default is "{}/YANG-rfc/"'.format(ietf_directory),
+                             f'Default is "{ietf_directory}/YANG-rfc/"',
                         type=str,
-                        default='{}/YANG-rfc/'.format(ietf_directory))
+                        default=f'{ietf_directory}/YANG-rfc/')
     parser.add_argument('--rfcextractionyangpath',
                         help='Path to the directory where to extract '
                              'the typedef, grouping, identity from data models extracted from RFCs. '
-                             'Default is "{}/YANG-rfc-extraction/"'.format(ietf_directory),
+                             f'Default is "{ietf_directory}/YANG-rfc-extraction/"',
                         type=str,
-                        default='{}/YANG-rfc-extraction/'.format(ietf_directory))
+                        default=f'{ietf_directory}/YANG-rfc-extraction/')
     parser.add_argument('--draftelementspath',
                         help='Path to the directory where to extract '
                              'the typedef, grouping, identity from data models correctely extracted from drafts. '
-                             'Default is "{}/draft-elements/"'.format(ietf_directory),
+                             f'Default is "{ietf_directory}/draft-elements/"',
                         type=str,
-                        default='{}/draft-elements/'.format(ietf_directory))
+                        default=f'{ietf_directory}/draft-elements/')
     parser.add_argument('--debug',
                         help='Debug level - default is 0',
                         type=int,
@@ -118,7 +118,7 @@ def main():
     args = parser.parse_args()
     if args.archived:
         draft_path = os.path.join(ietf_directory, 'my-id-archive-mirror')
-    custom_print('Start of {} job in {}'.format(os.path.basename(__file__), draft_path))
+    custom_print(f'Start of {os.path.basename(__file__)} job in {draft_path}')
     debug_level = args.debug
 
     draft_extractor_paths = {
@@ -151,29 +151,29 @@ def main():
         remove_directory_content(dir, debug_level)
 
     # Extract YANG models from IETF RFCs files
-    rfcExtractor = RFCExtractor(rfc_path, args.rfcyangpath, args.rfcextractionyangpath, debug_level)
-    rfcExtractor.extract()
-    rfcExtractor.clean_old_RFC_YANG_modules(args.rfcyangpath, args.yangexampleoldrfcpath)
+    rfc_extractor = RFCExtractor(rfc_path, args.rfcyangpath, args.rfcextractionyangpath, debug_level)
+    rfc_extractor.extract()
+    rfc_extractor.clean_old_RFC_YANG_modules(args.rfcyangpath, args.yangexampleoldrfcpath)
     custom_print('Old examples YANG modules moved')
     custom_print('All IETF RFCs pre-processed')
 
     # Extract YANG models from IETF draft files
-    draftExtractor = DraftExtractor(draft_extractor_paths, debug_level)
-    draftExtractor.extract()
-    draftExtractor.dump_incorrect_drafts(public_directory)
+    draft_extractor = DraftExtractor(draft_extractor_paths, debug_level)
+    draft_extractor.extract()
+    draft_extractor.dump_incorrect_drafts(public_directory)
     custom_print('All IETF Drafts pre-processed')
 
     # Dump dicts for later use by compile_modules.py
     with open(os.path.join(cache_directory, 'rfc_dict.json'), 'w') as f:
-        json.dump(rfcExtractor.inverted_rfc_yang_dict, f)
+        json.dump(rfc_extractor.inverted_rfc_yang_dict, f)
 
     with open(os.path.join(cache_directory, 'draft_dict.json'), 'w') as f:
-        json.dump(draftExtractor.inverted_draft_yang_dict, f)
+        json.dump(draft_extractor.inverted_draft_yang_dict, f)
 
     with open(os.path.join(cache_directory, 'example_dict.json'), 'w') as f:
-        json.dump(draftExtractor.inverted_draft_yang_example_dict, f)
+        json.dump(draft_extractor.inverted_draft_yang_example_dict, f)
 
-    custom_print('end of {} job'.format(os.path.basename(__file__)))
+    custom_print(f'end of {os.path.basename(__file__)} job')
 
 
 if __name__ == '__main__':

--- a/bin/extractors/dratf_extractor.py
+++ b/bin/extractors/dratf_extractor.py
@@ -21,18 +21,27 @@ import json
 import os
 import shutil
 import sys
+import typing as t
 from io import StringIO
+from json import JSONDecodeError
 
-from extract_elem import extract_elem
 from xym import xym
 
-from extractors.helper import (check_after_xym_extraction,
-                               invert_yang_modules_dict, remove_invalid_files)
+from extract_elem import extract_elem
+from extractors.helper import check_after_xym_extraction, invert_yang_modules_dict, remove_invalid_files
+from message_factory.message_factory import MessageFactory
 
 
 class DraftExtractor:
-    def __init__(self, draft_extractor_paths: dict, debug_level: int,
-                 extract_elements: bool = True, extract_examples: bool = True, copy_drafts: bool = True):
+    def __init__(
+            self,
+            draft_extractor_paths: dict,
+            debug_level: int,
+            extract_elements: bool = True,
+            extract_examples: bool = True,
+            copy_drafts: bool = True,
+            message_factory: t.Optional[MessageFactory] = None,
+    ):
         self.draft_path = draft_extractor_paths.get('draft_path', '')
         self.yang_path = draft_extractor_paths.get('yang_path', '')
         self.draft_elements_path = draft_extractor_paths.get('draft_elements_path', '')
@@ -54,6 +63,17 @@ class DraftExtractor:
         self.inverted_draft_yang_all_dict = {}
         self.drafts_missing_code_section = {}
         self._create_ietf_drafts_list()
+        self.message_factory = message_factory
+
+    @property
+    def message_factory(self):
+        if not self._message_factory:
+            self.message_factory = MessageFactory()
+        return self._message_factory
+
+    @message_factory.setter
+    def message_factory(self, value: t.Optional[MessageFactory]):
+        self._message_factory = value
 
     def _create_ietf_drafts_list(self):
         for filename in os.listdir(self.draft_path):
@@ -135,8 +155,9 @@ class DraftExtractor:
                 if self.copy_drafts:
                     shutil.copy2(draft_file_path, self.draft_path_no_strict)
 
-    def extract_from_draft_file(self, draft_file: str, srcdir: str, dstdir: str,
-                                strict: bool = False, strict_examples: bool = False):
+    def extract_from_draft_file(
+            self, draft_file: str, srcdir: str, dstdir: str, strict: bool = False, strict_examples: bool = False,
+    ):
 
         extracted = []
         old_stderr = None
@@ -177,17 +198,27 @@ class DraftExtractor:
                 extract_elem(module_fname, self.draft_elements_path, 'grouping')
                 extract_elem(module_fname, self.draft_elements_path, 'identity')
 
-    def dump_incorrect_drafts(self, public_directory: str):
-        """ Dump names of the IETF drafts with xym extraction error to
-        problematic_drafts.json file.
-        """
-        base_path = os.path.join(public_directory, 'drafts')
-        file_path = os.path.join(base_path, 'problematic_drafts.json')
+    def dump_incorrect_drafts(self, public_directory: str, send_emails_about_problematic_drafts: bool = True):
+        """Dump names of the IETF drafts with xym extraction error to problematic_drafts.json file."""
+        drafts_directory = os.path.join(public_directory, 'drafts')
+        os.makedirs(drafts_directory, exist_ok=True)
+        file_path = os.path.join(drafts_directory, 'problematic_drafts.json')
+        if send_emails_about_problematic_drafts:
+            if not os.path.exists(file_path):
+                with open(file_path, 'w') as f:
+                    f.write('{}')
+                old_incorrect_drafts = []
+            else:
+                with open(file_path, 'r') as f:
+                    old_incorrect_drafts = json.load(f)
+            self._send_email_about_new_problematic_drafts(old_incorrect_drafts)
+        with open(file_path, 'w') as writer:
+            json.dump(self.drafts_missing_code_section, writer)
 
-        try:
-            with open(file_path, 'w') as writer:
-                json.dump(self.drafts_missing_code_section, writer)
-        except FileNotFoundError:
-            os.makedirs(base_path)
-            with open(file_path, 'w') as writer:
-                json.dump(self.drafts_missing_code_section, writer)
+    def _send_email_about_new_problematic_drafts(self, old_incorrect_drafts: dict[str, str]):
+        for draft_filename, errors_string in self.drafts_missing_code_section.items():
+            if draft_filename in old_incorrect_drafts:
+                continue
+            author_email = f'{draft_filename.split(".")[0]}@ietf.org'
+            self.message_factory.send_problematic_draft([author_email], draft_filename, errors_string)
+

--- a/bin/extractors/dratf_extractor.py
+++ b/bin/extractors/dratf_extractor.py
@@ -68,7 +68,7 @@ class DraftExtractor:
     @property
     def message_factory(self):
         if not self._message_factory:
-            self.message_factory = MessageFactory()
+            self.message_factory = MessageFactory(close_connection_after_message_sending=False)
         return self._message_factory
 
     @message_factory.setter
@@ -207,15 +207,15 @@ class DraftExtractor:
             if not os.path.exists(file_path):
                 with open(file_path, 'w') as f:
                     f.write('{}')
-                old_incorrect_drafts = []
+                old_incorrect_drafts_keys = []
             else:
                 with open(file_path, 'r') as f:
-                    old_incorrect_drafts = json.load(f)
-            self._send_email_about_new_problematic_drafts(old_incorrect_drafts)
+                    old_incorrect_drafts_keys = json.load(f).keys()
+            self._send_email_about_new_problematic_drafts(old_incorrect_drafts_keys)
         with open(file_path, 'w') as writer:
             json.dump(self.drafts_missing_code_section, writer)
 
-    def _send_email_about_new_problematic_drafts(self, old_incorrect_drafts: dict[str, str]):
+    def _send_email_about_new_problematic_drafts(self, old_incorrect_drafts: t.Iterable[str]):
         for draft_filename, errors_string in self.drafts_missing_code_section.items():
             if draft_filename in old_incorrect_drafts:
                 continue

--- a/bin/extractors/dratf_extractor.py
+++ b/bin/extractors/dratf_extractor.py
@@ -219,6 +219,6 @@ class DraftExtractor:
         for draft_filename, errors_string in self.drafts_missing_code_section.items():
             if draft_filename in old_incorrect_drafts:
                 continue
-            author_email = f'{draft_filename.split(".")[0]}@ietf.org'
+            author_email = f'{draft_filename.split(".")[0].split("-")[0]}@ietf.org'
             self.message_factory.send_problematic_draft([author_email], draft_filename, errors_string)
 

--- a/bin/extractors/helper.py
+++ b/bin/extractors/helper.py
@@ -40,7 +40,7 @@ def invert_yang_modules_dict(in_dict: dict, debug_level: int = 0):
         print('DEBUG: invert_yang_modules_dict: dictionary before inversion:\n{}'.format(str(in_dict)))
 
     inv_dict = {}
-    for key, value in in_dict.items():
+    for key in in_dict.keys():
         for yang_model in in_dict[key]:
             inv_dict[yang_model] = key
 

--- a/bin/message_factory/message_factory.py
+++ b/bin/message_factory/message_factory.py
@@ -87,6 +87,6 @@ class MessageFactory:
         self._post_to_email(message, self._developers_email)
 
     def send_problematic_draft(self, email_to: list[str], draft_filename: str, errors: str):
-        subject = f'"{draft_filename}" had errors during extraction'
-        message = f'errors:\n{errors}'
+        subject = f'{GREETINGS}, "{draft_filename}" had errors during an extraction'
+        message = f'During a daily check of IETF drafts, some errors were found in "{draft_filename}":\n{errors}'
         self._post_to_email(message, email_to=email_to, subject=subject)

--- a/bin/message_factory/message_factory.py
+++ b/bin/message_factory/message_factory.py
@@ -43,10 +43,10 @@ class MessageFactory:
         self._temp_dir = config.get('Directory-Section', 'temp')
         self._me = config.get('Web-Section', 'domain-prefix').split('/')[-1]
         self._smtp = smtplib.SMTP('localhost')
-        self.close_connection_after_message_sending = close_connection_after_message_sending
+        self._close_connection_after_message_sending = close_connection_after_message_sending
 
     def __del__(self):
-        if not self.close_connection_after_message_sending:
+        if not self._close_connection_after_message_sending:
             self._smtp.quit()
 
     def _post_to_email(self, message: str, email_to: t.Optional[list] = None, subject: t.Optional[str] = None):
@@ -67,7 +67,7 @@ class MessageFactory:
             self._smtp.quit()
             return
         self._smtp.sendmail(self._email_from, send_to, msg.as_string())
-        if self.close_connection_after_message_sending:
+        if self._close_connection_after_message_sending:
             self._smtp.quit()
 
     def send_missing_modules(self, modules_list: list, incorrect_revision_modules: list):

--- a/bin/message_factory/message_factory.py
+++ b/bin/message_factory/message_factory.py
@@ -28,51 +28,55 @@ GREETINGS = 'Hello from yang-catalog'
 
 
 class MessageFactory:
-    """This class serves to automatically send an email to a group of admin/developers.
-    """
+    """This class serves to automatically email a group of admin/developers."""
 
     def __init__(self, config_path=os.environ['YANGCATALOG_CONFIG_PATH']):
         config = create_config(config_path)
-        self.__email_from = config.get('Message-Section', 'email-from')
-        self.__is_production = config.get('General-Section', 'is-prod')
-        self.__is_production = True if self.__is_production == 'True' else False
-        self.__email_to = config.get('Message-Section', 'email-to').split()
-        self.__developers_email = config.get('Message-Section', 'developers-email').split()
+        self._email_from = config.get('Message-Section', 'email-from')
+        self._is_production = config.get('General-Section', 'is-prod') == 'True'
+        self._email_to = config.get('Message-Section', 'email-to').split()
+        self._developers_email = config.get('Message-Section', 'developers-email').split()
         self._temp_dir = config.get('Directory-Section', 'temp')
-        self.__me = config.get('Web-Section', 'domain-prefix')
-        self.__me = self.__me.split('/')[-1]
-        self.__smtp = smtplib.SMTP('localhost')
+        self._me = config.get('Web-Section', 'domain-prefix').split('/')[-1]
+        self._smtp = smtplib.SMTP('localhost')
 
-    def __post_to_email(self, message: str, email_to: t.Optional[list] = None, subject: t.Optional[str] = None):
+    def _post_to_email(self, message: str, email_to: t.Optional[list] = None, subject: t.Optional[str] = None):
         """Send message to the list of e-mails.
 
             Arguments:
                 :param message      (str) message to send
                 :param email_to     (list) list of emails to send the message to
         """
-        send_to = email_to if email_to else self.__email_to
-        msg = MIMEText('{}\n\nMessage sent from {}'.format(message, self.__me))
-        msg['Subject'] = subject if subject else 'Automatic generated message - RFC IETF'
-        msg['From'] = self.__email_from
+        send_to = email_to or self._email_to
+        msg = MIMEText(f'{message}\n\nMessage sent from {self._me}')
+        msg['Subject'] = subject or 'Automatic generated message - RFC IETF'
+        msg['From'] = self._email_from
         msg['To'] = ', '.join(send_to)
 
-        if not self.__is_production:
-            print('You are in local env. Skip sending message to emails. The message was {}'.format(msg))
-            self.__smtp.quit()
+        if not self._is_production:
+            print(f'You are in local env. Skip sending message to emails. The message was {msg}')
+            self._smtp.quit()
             return
-        self.__smtp.sendmail(self.__email_from, send_to, msg.as_string())
-        self.__smtp.quit()
+        self._smtp.sendmail(self._email_from, send_to, msg.as_string())
+        self._smtp.quit()
 
     def send_missing_modules(self, modules_list: list, incorrect_revision_modules: list):
-        message = ('Following modules extracted from drafts are missing in YANG Catalog:\n')
-        path = os.path.join(self._temp_dir, 'drafts-missing-modules/yangmodels/yang/experimental/ietf-extracted-YANG-modules')
+        message = 'Following modules extracted from drafts are missing in YANG Catalog:\n'
+        path = os.path.join(
+            self._temp_dir, 'drafts-missing-modules/yangmodels/yang/experimental/ietf-extracted-YANG-modules',
+        )
         for module in modules_list:
-            message += '{}\n'.format(module)
-        message += '\nAll missing modules have been copied to the directory: {}'.format(path)
+            message += f'{module}\n'
+        message += f'\nAll missing modules have been copied to the directory: {path}'
 
         if incorrect_revision_modules:
             message += '\n\nFollowing missing modules do not have revision in the correct format:\n'
             for module in incorrect_revision_modules:
-                message += '{}\n'.format(module)
+                message += f'{module}\n'
 
-        self.__post_to_email(message, self.__developers_email)
+        self._post_to_email(message, self._developers_email)
+
+    def send_problematic_draft(self, email_to: list[str], draft_filename: str, errors: str):
+        subject = f'"{draft_filename}" had errors during extraction'
+        message = f'errors:\n{errors}'
+        self._post_to_email(message, email_to=email_to, subject=subject)


### PR DESCRIPTION
Added email sending for authors of new problematic drafts.
I am not sure about the solution with the use of destructor in MessageFactory class, maybe it would be better to use a context manager here.
Messages look like this:
![image](https://user-images.githubusercontent.com/60445869/189622150-d9643232-7876-4ceb-b1fc-26d7d7bcf3b6.png)
I'm also not sure about the extraction of author names from draft files names because following [this](https://github.com/YangCatalog/sdo_analysis/blob/master/bin/metadata_generators/draft_metadata_generator.py#L22) example locally I get something like ```draft-ietf-netconf-keystore-25``` as can be seen above

resolves #194 